### PR TITLE
Minor fixes

### DIFF
--- a/source/core/exception.d
+++ b/source/core/exception.d
@@ -79,33 +79,36 @@ extern (C)
 
     void _d_arraybounds(string file, size_t line) {
 
-        version (WebAssembly)
-            arsd.webassembly.eval(
-                q{ console.error("Range error: " + $0 + ":" + $1 )},
-                file, line);
-        else version (CustomRuntimePrinter)
+        // version (WebAssembly)
+        //     arsd.webassembly.eval(
+        //         q{ console.error("Range error: " + $0 + ":" + $1 )},
+        //         file, line);
+        // else
+        version (CustomRuntimePrinter)
             customRuntimePrinter("Range Error: ", file, ":", line);
         abort();
     }
 
     /// Called when an out of range slice of an array is created
     void _d_arraybounds_slice(string file, uint line, size_t lwr, size_t upr, size_t length) {
-        version (WebAssembly)
-            arsd.webassembly.eval(
-                q{ console.error("Range error: " + $0 + ":" + $1 + " [" + $2 + ".." + $3 + "] <> " + $4)},
-                file, line, lwr, upr, length);
-        else version (CustomRuntimePrinter)
+        // version (WebAssembly)
+        //     arsd.webassembly.eval(
+        //         q{ console.error("Range error: " + $0 + ":" + $1 + " [" + $2 + ".." + $3 + "] <> " + $4)},
+        //         file, line, lwr, upr, length);
+        // else
+        version (CustomRuntimePrinter)
             customRuntimePrinter("Range Error: ", file, ":", line, " [", lwr, "..", upr, "] <> ", length);
         abort();
     }
 
     /// Called when an out of range array index is accessed
     void _d_arraybounds_index(string file, uint line, size_t index, size_t length) {
-        version (WebAssembly)
-            arsd.webassembly.eval(
-                q{ console.error("Array index " + $0  + " out of bounds '[0.."+$1+"]' " + $2 + ":" + $3)},
-                index, length, file, line);
-        else version (CustomRuntimePrinter)
+        // version (WebAssembly)
+            // arsd.webassembly.eval(
+            //     q{ console.error("Array index " + $0  + " out of bounds '[0.."+$1+"]' " + $2 + ":" + $3)},
+            //     index, length, file, line);
+        // else
+        version (CustomRuntimePrinter)
             customRuntimePrinter("Array index: ", index, " out of bounds '[0..", length, "]'", file, ":", line);
         abort();
     }


### PR DESCRIPTION
fix #1 

### Changes
* aa (associative array) support added
* deactivated arsd.webassembly in exception.d (arsd modules missing)
* fixing `_d_newitemT` between runtime version

## Running tests

**Note:** `user-data` use AA and some examples, like `saudio` need `_d_arraybounds_index` (no betterC build)
<details>
<summary>build all examples</summary>

```diff
@@ -227,12 +227,18 @@ pub fn build(b: *Build) !void {
             const ldc = try ldcBuildStep(b, .{
                 .name = example,
                 .artifact = lib_sokol,
-                .sources = &[_][]const u8{b.fmt("{s}/src/examples/{s}.d", .{ rootPath(), example })},
+                .sources = &[_][]const u8{
+                    b.fmt("{s}/src/examples/{s}.d", .{ rootPath(), example }),
+                    "/home/kassane/tinyd-rt/source/core/exception.d",
+                },
                 .betterC = if (std.mem.eql(u8, example, "user-data")) false else enable_betterC,
                 .dflags = &[_][]const u8{
                     "-w", // warnings as error
                     // more info: ldc2 -preview=help (list all specs)
                     "-preview=all",
+                    "-I/home/kassane/tinyd-rt/source/",
+                    "-conf=",
+                    "-defaultlib=",
                 },
```

```bash
$ zig build --summary new -Dtarget=wasm32-emscripten-none -Doptimize=ReleaseSafe
Build Summary: 33/33 steps succeeded
install success
├─ emcc success 8s MaxRSS:644M
│  ├─ zig build-obj clear ReleaseSafe wasm32-emscripten-none success 42ms MaxRSS:34M
│  │  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none success 1s MaxRSS:134M
│  │  ├─ WriteFile success
│  │  └─ clear success 141ms MaxRSS:85M
│  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  └─ clear (reused)
├─ clear (reused)
├─ emcc success 8s MaxRSS:661M
│  ├─ zig build-obj triangle ReleaseSafe wasm32-emscripten-none success 42ms MaxRSS:34M
│  │  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  │  ├─ WriteFile (reused)
│  │  └─ triangle success 161ms MaxRSS:86M
│  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  └─ triangle (reused)
├─ triangle (reused)
├─ emcc success 8s MaxRSS:652M
│  ├─ zig build-obj cube ReleaseSafe wasm32-emscripten-none success 33ms MaxRSS:38M
│  │  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  │  ├─ WriteFile (reused)
│  │  └─ cube success 225ms MaxRSS:88M
│  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  └─ cube (reused)
├─ cube (reused)
├─ emcc success 8s MaxRSS:668M
│  ├─ zig build-obj blend ReleaseSafe wasm32-emscripten-none success 41ms MaxRSS:37M
│  │  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  │  ├─ WriteFile (reused)
│  │  └─ blend success 206ms MaxRSS:87M
│  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  └─ blend (reused)
├─ blend (reused)
├─ emcc success 8s MaxRSS:642M
│  ├─ zig build-obj mrt ReleaseSafe wasm32-emscripten-none success 41ms MaxRSS:36M
│  │  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  │  ├─ WriteFile (reused)
│  │  └─ mrt success 263ms MaxRSS:91M
│  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  └─ mrt (reused)
├─ mrt (reused)
├─ emcc success 8s MaxRSS:635M
│  ├─ zig build-obj saudio ReleaseSafe wasm32-emscripten-none success 41ms MaxRSS:35M
│  │  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  │  ├─ WriteFile (reused)
│  │  └─ saudio success 187ms MaxRSS:85M
│  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  └─ saudio (reused)
├─ saudio (reused)
├─ emcc success 8s MaxRSS:642M
│  ├─ zig build-obj sgl_context ReleaseSafe wasm32-emscripten-none success 41ms MaxRSS:36M
│  │  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  │  ├─ WriteFile (reused)
│  │  └─ sgl_context success 182ms MaxRSS:88M
│  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  └─ sgl_context (reused)
├─ sgl_context (reused)
├─ emcc success 5s MaxRSS:663M
│  ├─ zig build-obj sgl_points ReleaseSafe wasm32-emscripten-none success 8s MaxRSS:35M
│  │  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  │  ├─ WriteFile (reused)
│  │  └─ sgl_points success 204ms MaxRSS:88M
│  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  └─ sgl_points (reused)
├─ sgl_points (reused)
├─ emcc success 8s MaxRSS:646M
│  ├─ zig build-obj debugtext ReleaseSafe wasm32-emscripten-none success 33ms MaxRSS:35M
│  │  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  │  ├─ WriteFile (reused)
│  │  └─ debugtext success 161ms MaxRSS:85M
│  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  └─ debugtext (reused)
├─ debugtext (reused)
├─ emcc success 8s MaxRSS:652M
│  ├─ zig build-obj user_data ReleaseSafe wasm32-emscripten-none success 31ms MaxRSS:38M
│  │  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  │  ├─ WriteFile (reused)
│  │  └─ user_data success 146ms MaxRSS:85M
│  ├─ zig build-lib sokol ReleaseSafe wasm32-emscripten-none (reused)
│  └─ user_data (reused)
└─ user_data (reused)
```
</details>

cc: @LunaTheFoxgirl 